### PR TITLE
fix: action with pr

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -2,7 +2,7 @@ name: Prepare Release PR
 
 on:
   push:
-    branches: [main, master]   # se ejecuta cuando merges normales entran a main
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:
@@ -11,8 +11,8 @@ permissions:
 
 jobs:
   prepare:
-    # evita loop cuando el commit ya es "chore(release): vX.Y.Z"
-    if: "! contains(github.event.head_commit.message, 'chore(release)')"
+    # IMPORTANTE: expresión válida con ${{ }}
+    if: ${{ ! contains(github.event.head_commit.message, 'chore(release)') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -44,13 +44,15 @@ jobs:
         run: |
           semantic-release version --no-push --no-tag --no-vcs-release
 
-          # Lee la versión del pyproject
-          python - <<'PY' | tee -a $GITHUB_ENV
-import tomllib
-d = tomllib.load(open("pyproject.toml","rb"))
-v = (d.get("project",{}) or d.get("tool",{}).get("poetry",{})).get("version")
-print(f"VERSION={v}")
-PY
+          # Leer VERSION desde pyproject.toml (todo INDENTADO)
+          python - <<'PY' > .version
+          import tomllib
+          with open("pyproject.toml","rb") as f:
+              d = tomllib.load(f)
+          v = (d.get("project",{}) or d.get("tool",{}).get("poetry",{})).get("version","")
+          print(v, end="")
+          PY
+          echo "VERSION=$(cat .version)" >> $GITHUB_ENV
 
       - name: Push branch
         run: git push --set-upstream origin "$BRANCH"
@@ -69,13 +71,13 @@ PY
           echo "PR_NUMBER=$PR" >> $GITHUB_ENV
 
       - name: Approve PR
-        if: env.PR_NUMBER != ''
+        if: ${{ env.PR_NUMBER != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr review $PR_NUMBER --approve
 
       - name: Enable auto-merge (squash)
-        if: env.PR_NUMBER != ''
+        if: ${{ env.PR_NUMBER != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge $PR_NUMBER --auto --squash

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -9,17 +9,24 @@ permissions:
 
 jobs:
   tag:
-    if: contains(github.event.head_commit.message, 'chore(release): v')
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
 
-      - name: Create and push tag from commit message
+      # Extrae la versión SOLO si el commit trae "chore(release): vX.Y.Z"
+      - name: Extract version from commit message
+        id: v
         env:
           MSG: ${{ github.event.head_commit.message }}
         run: |
           VERSION=$(echo "$MSG" | sed -n 's/.*chore(release): v\([0-9][0-9.]*\).*/\1/p')
-          test -n "$VERSION" || { echo "No version found"; exit 1; }
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: ${{ steps.v.outputs.version != '' }}
+        run: |
+          git tag "v${{ steps.v.outputs.version }}"
+          git push origin "v${{ steps.v.outputs.version }}"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for release preparation and tagging to improve reliability and correctness. The main improvements include switching to the recommended `${{ }}` syntax for workflow expressions, refining how the release version is extracted from `pyproject.toml`, and making the tagging process more robust by conditionally creating tags only when a valid version is detected.

**Workflow expression and logic improvements:**

* Updated all workflow conditionals to use the correct `${{ }}` syntax for expressions, ensuring that steps only run under the intended conditions in both `release-pr.yml` and `tag-on-merge.yml`. [[1]](diffhunk://#diff-6d2776058621d57e67ee850e7db85691f8747f8bfa43021c3eb0663e78c8f2e8L14-R15) [[2]](diffhunk://#diff-6d2776058621d57e67ee850e7db85691f8747f8bfa43021c3eb0663e78c8f2e8L72-R80)

**Release version extraction improvements:**

* Refined the Python script in `release-pr.yml` to read the version from `pyproject.toml` and output it to a temporary file, then set the `VERSION` environment variable from this file for subsequent steps.

**Tagging process enhancements:**

* Changed the tagging workflow to extract the version from the commit message using a dedicated step, storing it as an output, and only creating/pushing a tag if a valid version is found. This prevents accidental tagging and ensures tags match the release version.

These changes make the release automation more robust and easier to maintain.