### PR TITLE
fix: action with pr

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           semantic-release version --no-push --no-tag --no-vcs-release
 
-          # Leer VERSION desde pyproject.toml (todo INDENTADO)
+          # Leer VERSION desde pyproject.toml
           python - <<'PY' > .version
           import tomllib
           with open("pyproject.toml","rb") as f:
@@ -54,10 +54,28 @@ jobs:
           PY
           echo "VERSION=$(cat .version)" >> $GITHUB_ENV
 
+          # Si PSR no dejó commit (p.ej., no había changes), intentamos commitear cualquier diff pendiente
+          if ! git diff --quiet; then
+            git add -A
+            git commit -m "chore(release): v${VERSION}"
+          fi
+
+      - name: Check if branch differs from main
+        run: |
+          git fetch origin main
+          if git diff --quiet origin/main...HEAD; then
+            echo "NO_CHANGES=1" >> $GITHUB_ENV
+            echo "No hay cambios vs main; se omite PR."
+          else
+            echo "NO_CHANGES=0" >> $GITHUB_ENV
+          fi
+
       - name: Push branch
+        if: ${{ env.NO_CHANGES == '0' }}
         run: git push --set-upstream origin "$BRANCH"
 
       - name: Open PR
+        if: ${{ env.NO_CHANGES == '0' }}
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,13 +89,13 @@ jobs:
           echo "PR_NUMBER=$PR" >> $GITHUB_ENV
 
       - name: Approve PR
-        if: ${{ env.PR_NUMBER != '' }}
+        if: ${{ env.NO_CHANGES == '0' && env.PR_NUMBER != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr review $PR_NUMBER --approve
 
       - name: Enable auto-merge (squash)
-        if: ${{ env.PR_NUMBER != '' }}
+        if: ${{ env.NO_CHANGES == '0' && env.PR_NUMBER != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge $PR_NUMBER --auto --squash


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release-pr.yml` to make the process more robust and avoid unnecessary pull requests when there are no changes compared to `main`. The main improvements are in conditional logic for committing, pushing, and opening PRs.

**Workflow logic improvements:**

* Added a check to see if there are any changes between the current branch and `main`, and set a `NO_CHANGES` flag accordingly to prevent opening PRs when there are no differences.
* Updated the workflow steps for pushing the branch, opening a PR, approving the PR, and enabling auto-merge to only run if there are actual changes, using the new `NO_CHANGES` flag as a condition. [[1]](diffhunk://#diff-6d2776058621d57e67ee850e7db85691f8747f8bfa43021c3eb0663e78c8f2e8R57-R78) [[2]](diffhunk://#diff-6d2776058621d57e67ee850e7db85691f8747f8bfa43021c3eb0663e78c8f2e8L74-R98)

**Commit handling:**

* Added logic to commit any pending diffs if the release step did not create a commit (for example, when there were no changes detected by the release tool).

**Minor cleanup:**

* Updated a comment to clarify the reading of the version from `pyproject.toml`.