### PR TITLE
fix: action with pr

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main, master]
   workflow_dispatch:
+    inputs:
+      force_level:
+        description: "Forzar release: none/patch/minor/major"
+        required: false
+        default: "none"
 
 permissions:
   contents: write
@@ -38,23 +43,77 @@ jobs:
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
           git checkout -b "$BRANCH"
 
-      - name: Bump version (NO push / NO tag)
+      - name: Bump version (auto o forzado) — NO push/NO tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE_LEVEL: ${{ inputs.force_level }}
         run: |
-          semantic-release version --no-push --no-tag --no-vcs-release
+          set -e
 
-          # Leer VERSION desde pyproject.toml
-          python - <<'PY' > .version
-          import tomllib
-          with open("pyproject.toml","rb") as f:
-              d = tomllib.load(f)
-          v = (d.get("project",{}) or d.get("tool",{}).get("poetry",{})).get("version","")
-          print(v, end="")
-          PY
-          echo "VERSION=$(cat .version)" >> $GITHUB_ENV
+          if [ "${FORCE_LEVEL:-none}" != "none" ]; then
+            echo ">> Forzando bump ${FORCE_LEVEL}"
+            python - <<'PY'
+            import re, sys, pathlib, tomllib
 
-          # Si PSR no dejó commit (p.ej., no había changes), intentamos commitear cualquier diff pendiente
+            path = pathlib.Path("pyproject.toml")
+            txt  = path.read_text(encoding="utf-8")
+            data = tomllib.loads(txt)
+
+            def get_ver(d):
+                if "project" in d and "version" in d["project"]:
+                    return d["project"]["version"]
+                tp = d.get("tool", {}).get("poetry", {})
+                return tp.get("version")
+
+            old = get_ver(data)
+            if not old:
+                print("No se encontró version en [project] ni [tool.poetry]", file=sys.stderr)
+                sys.exit(1)
+
+            def bump(v, kind):
+                m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", v)
+                if not m: raise SystemExit(f"Version no semver: {v}")
+                M, mnr, p = map(int, m.groups())
+                if kind == "major":
+                    return f"{M+1}.0.0"
+                if kind == "minor":
+                    return f"{M}.{mnr+1}.0"
+                return f"{M}.{mnr}.{p+1}"  # patch
+
+            kind = "${FORCE_LEVEL}".lower()
+            new = bump(old, kind)
+
+            # Reemplazo simple de la primera ocurrencia exacta
+            txt_new = txt.replace(f'version = "{old}"', f'version = "{new}"', 1)
+            path.write_text(txt_new, encoding="utf-8")
+            print(new, end="")
+            PY
+                        VERSION=$(python - <<'PY'
+            import tomllib
+            with open("pyproject.toml","rb") as f:
+                d = tomllib.load(f)
+            v = (d.get("project",{}) or d.get("tool",{}).get("poetry",{})).get("version","")
+            print(v, end="")
+            PY
+            )
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+          else
+            echo ">> Modo automático con python-semantic-release"
+            semantic-release version --no-push --no-tag --no-vcs-release || true
+
+            # Leer versión detectada (si hubo cambio)
+            python - <<'PY' > .version
+            import tomllib
+            with open("pyproject.toml","rb") as f:
+                d = tomllib.load(f)
+            v = (d.get("project",{}) or d.get("tool",{}).get("poetry",{})).get("version","")
+            print(v, end="")
+            PY
+            echo "VERSION=$(cat .version)" >> $GITHUB_ENV
+          fi
+
+          # Si hay diffs, commit explícito con el mensaje de release
           if ! git diff --quiet; then
             git add -A
             git commit -m "chore(release): v${VERSION}"


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release-pr.yml` to support both automatic and manual version bumping during a release. The main improvement is the addition of a workflow input that allows users to force a specific version bump level (patch, minor, or major), and the corresponding logic to handle this in the workflow steps.

**Release workflow enhancements:**

* Added a new `force_level` input to the workflow, allowing users to manually specify the version bump type (none/patch/minor/major) when triggering a release.

* Updated the version bump step to support both automatic and forced version increments:
  - If `force_level` is set, a Python script directly updates the version in `pyproject.toml` based on the specified level.
  - If not set, the workflow defaults to using `semantic-release` for automatic versioning.

* Improved version extraction logic to ensure the correct version is read from `pyproject.toml` after the bump, regardless of method used.

**Commit logic improvements:**

* Changed the commit step to always commit any detected diffs with a release message, ensuring that version changes are captured even if `semantic-release` does not create a commit.